### PR TITLE
fix: handle FormData Network error Expo bug

### DIFF
--- a/backend/src/controllers/PointsController.ts
+++ b/backend/src/controllers/PointsController.ts
@@ -35,6 +35,8 @@ export default {
       latitude,
       longitude,
     } = request.body;
+
+    console.log(" >>> received request: ", name, about, latitude, longitude);
     
     const pointsRepository = getRepository(Point);
     const requestImages = request.files as Express.Multer.File[];

--- a/mobile/src/pages/CreatePoint/PointData.tsx
+++ b/mobile/src/pages/CreatePoint/PointData.tsx
@@ -3,7 +3,8 @@ import { Image, ScrollView, View, StyleSheet, Text, TextInput, TouchableOpacity 
 import { Feather } from '@expo/vector-icons';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import * as ImagePicker from 'expo-image-picker';
-import api from '../../services/api';
+
+import { sendXmlHttpRequest } from '../../services/sendMultipartForm';
 
 interface PointDataRouteParams {
   position: {
@@ -40,7 +41,15 @@ export default function PointData() {
       } as any)
     });
 
-    await api.post('points', data);
+    // await api.post('points', data);
+
+    try {
+      const response = await sendXmlHttpRequest(data);
+      console.log(" >>>> response", response);
+    } catch (err) {
+      // tratar adequadamente o erro para mostrar uma mensagem de erro
+      console.log(err);
+    }
 
     navigation.navigate('PointsMap');
 

--- a/mobile/src/services/sendMultipartForm.ts
+++ b/mobile/src/services/sendMultipartForm.ts
@@ -1,0 +1,19 @@
+export const sendXmlHttpRequest = (data: FormData) => {
+    const xhr = new XMLHttpRequest();
+
+    return new Promise((resolve, reject) => {
+      xhr.onreadystatechange = (e) => {
+        if (xhr.readyState !== 4) {
+          return;
+        }
+
+        if ([200, 201].includes(xhr.status)) {
+          resolve(JSON.parse(xhr.responseText));
+        } else {
+          reject("Request Failed");
+        }
+      };
+      xhr.open("POST", "http://192.168.15.5:3333/points");
+      xhr.send(data);
+    });
+}


### PR DESCRIPTION
A bug related to the FormData network process in Expo caused issues when posting data.

More details can be found in:
 - https://github.com/expo/expo/issues/16451
 - https://github.com/expo/expo/issues/2402#issuecomment-443726662
 - https://stackoverflow.com/questions/60987459/react-native-with-expo-fetch-with-formdata-network-error-on-android-only/64397804#64397804

**IMPORTANT**: in the `sendXmlHttpRequest` function I have directly included the POST url (`/points`). To make the function reusable, it is important to parameterize the URL or any necessary header through function parameters.